### PR TITLE
update-alpine-version-to-3.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ COPY ./ /src/
 WORKDIR /src/
 RUN ./gradlew --info --no-daemon build
 
-FROM quay.io/pires/docker-jre:8u171
+FROM quay.io/pires/docker-jre:8u171_alpine_3.8.1
 
 ENV ALLOWED_USER_AGENTS_ON_ROOT_REGEX "GoogleHC"
 ENV AUTH_CACHE_TTL "300"


### PR DESCRIPTION
Updating Alpine version to 3.8.1 due to:
https://justi.cz/security/2018/09/13/alpine-apk-rce.html